### PR TITLE
Replace "Limit FPS back down to 60" option with "Raise FPS to match display refresh rate"

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Core Patches (always enabled):
 - Save & Log Location Fixer - Loads save.dat from current working directory and sends game logs to log.txt residing in current working directory
 
 User-facing, most notable/impactful patches:
-- Framerate Unlock patch - Adjusts the game's framerate limit to match the users display refresh rate. Additionally fixes some visuals caused by higher FPS
+- Framerate Unlock patch - Provides an option to raise the game's framerate limit to match the user's display refresh rate (default: 60 FPS).
 - Audio stuttering patch - Forces the game to stream all audio files from disk rather than try load in memory. Playback from memory is broken on Proton's AudioManager FMOD backend
 - Server Switcher - You can now connect to any server that supports V3.02 without modifying hosts file with this mod
 - Cache Location Fixer - Binds game's cache folder to the same folder game installation is on. Useful for people that have multiple Growtopia installations

--- a/patches.txt
+++ b/patches.txt
@@ -6,6 +6,7 @@ Audio stuttering fix (e.g. party blaster stutter).
 +audio_stutter_fix
 
 Adds option to raise framerate to match primary monitor (Default: 60 FPS).
++framerate_unlock
 
 Remove chat margin, chat tabs and [S] chat stuff.
 +enable_legacy_chat

--- a/patches.txt
+++ b/patches.txt
@@ -5,8 +5,7 @@ mess with the file parsing process.
 Audio stuttering fix (e.g. party blaster stutter).
 +audio_stutter_fix
 
-Unlock game framerate to match primary monitor.
-+framerate_unlock
+Adds option to raise framerate to match primary monitor (Default: 60 FPS).
 
 Remove chat margin, chat tabs and [S] chat stuff.
 +enable_legacy_chat


### PR DESCRIPTION
Fix for this issue: https://github.com/gtModLoader/osgt-qol/issues/28.
Now has FPS as 60 by default, you must unlock it with the checkbox.

<img width="1598" height="373" alt="image" src="https://github.com/user-attachments/assets/c36e927c-a96e-418f-87e2-f851a8fc3fee" />
